### PR TITLE
Release job for ABIs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*.*.*'
   pull_request:
 
 jobs:
@@ -22,3 +24,13 @@ jobs:
 
       - name: Run Tests
         run: FOUNDRY_PROFILE=ci forge test
+
+      - name: Publish ABIs
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ABIs
+          files: | 
+            ./out/Multicall.sol/Multicall.json
+            ./out/Multicall2.sol/Multicall2.json
+            ./out/Multicall3.sol/Multicall3.json


### PR DESCRIPTION
I wanted to easily get the Multicall3 ABI, but I needed to clone and build. Not too big an issue but I think others might find it helpful if the ABI was already available in the releases tab.

If you merge this PR and make a release / tag, the ABIs will be published. I ran a quick test on my forked branch, it will look like this: https://github.com/devanonon/multicall/releases/tag/v1.0.0

Of course you can give it some nicer message. :)

