### PR TITLE
fix: update Foundry config

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,16 +3,16 @@
 # See more config options at: https://github.com/gakonst/foundry/tree/master/config
 
 # The Default Profile
-[default]
+[profile.default]
 # Sets the concrete solc version to use
 # This overrides the `auto_detect_solc` value
-solc_version = '0.8.12'
+solc_version = "0.8.12"
 auto_detect_solc = false
 # Increase optimizer_runs since we expect multicalls to be highly queried
 optimizer = true
 optimizer_runs = 10_000_000
 # Fuzz more than the default 256
-fuzz_runs = 1_000
+fuzz = { runs = 1_000 }
 # Configure remappings
 remappings = [
   "@ds=lib/ds-test/src/",
@@ -20,5 +20,5 @@ remappings = [
 ]
 
 # Extreme Fuzzing CI Profile :P
-[ci]
+[profile.ci]
 fuzz_runs = 100_000


### PR DESCRIPTION
Updates the Foundry config to fix the warnings that get logged with the latest version of Foundry.

- `default` is now `profile.default`
- `ci` is now `profile.ci`
- `fuzz_runs` is now `fuzz.runs`