### PR TITLE
Update deployments.json

### DIFF
--- a/deployments.json
+++ b/deployments.json
@@ -337,7 +337,7 @@
   {
     "name": "Canto",
     "chainId": 7700,
-    "url": "https://evm.explorer.canto.io/address/0xcA11bde05977b3631167028862bE2a173976CA11/contracts#address-tabs"
+    "url": "https://tuber.build/address/0xcA11bde05977b3631167028862bE2a173976CA11/contracts#address-tabs"
   },
   {
     "name": "Canto Testnet",


### PR DESCRIPTION
fix link for canto. The current link would get redirected to https://tuber.build/$#address-tabs