### PR TITLE
Add deployment details for CORE, Ethereum Classic and Frame Testnet

### DIFF
--- a/deployments.json
+++ b/deployments.json
@@ -715,6 +715,21 @@
     "url": "https://scan.chiliz.com/address/0xcA11bde05977b3631167028862bE2a173976CA11/contracts#address-tabs"
   },
   {
+    "name": "CORE",
+    "chainId": 1116,
+    "url": "https://scan.coredao.org/address/0xcA11bde05977b3631167028862bE2a173976CA11#code"
+  },
+  {
+    "name": "Ethereum Classic",
+    "chainId": 61,
+    "url": "https://etc.blockscout.com/address/0xcA11bde05977b3631167028862bE2a173976CA11"
+  },
+  {
+    "name": "Frame Testnet",
+    "chainId": 68840142,
+    "url": "https://explorer.testnet.frame.xyz/address/0xcA11bde05977b3631167028862bE2a173976CA11"
+  },
+  {
     "name": "Tron",
     "chainId": 728126428,
     "url": "https://tronscan.org/#/contract/TEazPvZwDjDtFeJupyo7QunvnrnUjPH8ED/code",


### PR DESCRIPTION
I didn't deploy any of these contracts, but noticed that these deployment details were missing from `deployments.json`.