### PR TITLE
chore: replace invalid url for linea mainnet

### DIFF
--- a/deployments.json
+++ b/deployments.json
@@ -417,7 +417,7 @@
   {
     "name": "Linea Mainnet",
     "chainId": 59144,
-    "url": "https://lineascan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11#code"
+    "url": "https://lineascan.build/address/0xcA11bde05977b3631167028862bE2a173976CA11#code"
   },
   {
     "name": "Hashbit",


### PR DESCRIPTION
https://lineascan.io is currently unavailable.