### PR TITLE
chore: add DeFiChain EVM deployment

### DIFF
--- a/deployments.json
+++ b/deployments.json
@@ -400,6 +400,16 @@
     "url": "https://basescan.org/address/0xca11bde05977b3631167028862be2a173976ca11#code"
   },
   {
+    "name": "DeFiChain EVM Mainnet",
+    "chainId": 1130,
+    "url": "https://meta.defiscan.live/address/0xcA11bde05977b3631167028862bE2a173976CA11"
+  },
+  {
+    "name": "DeFiChain EVM Testnet",
+    "chainId": 1131,
+    "url": "https://meta.defiscan.live/address/0xcA11bde05977b3631167028862bE2a173976CA11?network=TestNet"
+  },
+  {
     "name": "DFK Chain Test",
     "chainId": 335,
     "url": "https://subnets-test.avax.network/defi-kingdoms/address/0xcA11bde05977b3631167028862bE2a173976CA11"


### PR DESCRIPTION
- Added `DeFiChain EVM Mainnet` (chain id `1130`) and `DeFiChain EVM Testnet` (chain id `1131`) to `deployments.json`
  - https://meta.defiscan.live/address/0xcA11bde05977b3631167028862bE2a173976CA11
  - https://meta.defiscan.live/address/0xcA11bde05977b3631167028862bE2a173976CA11?network=TestNet
