### PR TITLE
Add Multicall3 deployment for Rupaya network

### DIFF
--- a/deployments.json
+++ b/deployments.json
@@ -1213,5 +1213,10 @@
     "name": "Superseed",
     "chainId": 53302,
     "url": "https://sepolia-explorer.superseed.xyz/address/0xcA11bde05977b3631167028862bE2a173976CA11"
+  },
+  {
+    "name": "Rupaya",
+    "chainId": 499,
+    "url": "https://scan.rupaya.io/address/0xcA11bde05977b3631167028862bE2a173976CA11"
   }
 ]


### PR DESCRIPTION
- Network Name: Rupaya

- Chain ID: 499

- Deployment Transaction Hash: [0x07471adfe8f4ec553c1199f495be97fc8be8e0626ae307281c22534460184ed1](https://scan.rupaya.io/tx/0x07471adfe8f4ec553c1199f495be97fc8be8e0626ae307281c22534460184ed1)


- Block Number: 35231 (0x899f in hex)

- Date of Deployment: 01-09-2024

This PR adds the Multicall3 deployment information for the Rupaya network to the deployments.json file.