### PR TITLE
chore: add conflux core space mainnet

### DIFF
--- a/deployments.json
+++ b/deployments.json
@@ -1279,5 +1279,11 @@
     "name": "Flow Testnet",
     "chainId": 545,
     "url": "https://evm-testnet.flowscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
+  },
+  {
+    "name": "Conflux Core Space Mainnet",
+    "chainId": 1029,
+    "url": "https://confluxscan.io/address/cfx:acevn2d3dr6vh4jca28c6cmvkktsg7r8n25vp9hnmw?tab=contract-viewer",
+    "address": "cfx:acevn2d3dr6vh4jca28c6cmvkktsg7r8n25vp9hnmw"
   }
 ]


### PR DESCRIPTION
The Conflux Core Space address is incompatible with EVM, so I deployed the contract myself.