### PR TITLE
fix: update link for iota evm

### DIFF
--- a/deployments.json
+++ b/deployments.json
@@ -1083,7 +1083,7 @@
   {
     "name": "IOTA EVM",
     "chainId": 8822,
-    "url": "https://iota-evm.blockscout.com/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
+    "url": "https://explorer.evm.iota.org/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
   },
   {
     "name": "Planq",


### PR DESCRIPTION
The current link would be redirected to https://explorer.evm.iota.org/