### PR TITLE
chore: update Plume mainnet and testnet

### DIFF
--- a/deployments.json
+++ b/deployments.json
@@ -1227,19 +1227,14 @@
     "url": "https://explorer.testnet.nahmii.io/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
   },
   {
-    "name": "Plume Testnet",
-    "chainId": 161221135,
-    "url": "https://testnet-explorer.plumenetwork.xyz/address/0xca11bde05977b3631167028862be2a173976ca11?tab=contract"
-  },
-  {
-    "name": "Plume Testnet v2",
-    "chainId": 98864,
-    "url": "https://test-explorer.plumenetwork.xyz/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
-  },
-  {
     "name": "Plume Mainnet",
-    "chainId": 98865,
-    "url": "https://phoenix-explorer.plumenetwork.xyz/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
+    "chainId": 98866,
+    "url": "https://phoenix-explorer.plumenetwork.xyz/address/0xca11bde05977b3631167028862be2a173976ca11?tab=contract"
+  },
+  {
+    "name": "Plume Testnet",
+    "chainId": 98867,
+    "url": "https://testnet-explorer.plumenetwork.xyz/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
   },
   {
     "name": "Algen L1",

--- a/deployments.json
+++ b/deployments.json
@@ -1227,14 +1227,14 @@
     "url": "https://explorer.testnet.nahmii.io/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
   },
   {
-    "name": "Plume Mainnet",
-    "chainId": 98866,
-    "url": "https://phoenix-explorer.plumenetwork.xyz/address/0xca11bde05977b3631167028862be2a173976ca11?tab=contract"
-  },
-  {
     "name": "Plume Testnet",
     "chainId": 98867,
-    "url": "https://testnet-explorer.plumenetwork.xyz/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
+    "url": "https://testnet-explorer.plumenetwork.xyz/address/0xca11bde05977b3631167028862be2a173976ca11?tab=contract"
+  },
+  {
+    "name": "Plume Mainnet",
+    "chainId": 98866,
+    "url": "https://phoenix-explorer.plumenetwork.xyz/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
   },
   {
     "name": "Algen L1",


### PR DESCRIPTION
The previous Plume mainnet with chain ID 98865 and the previous Plume testnets with chain IDs 98864 and 161221135 are now deprecated, and replaced with the new Plume mainnet with chain ID 98866 and the new Plume testnet with chain ID 98867.