### PR TITLE
chore: add Fluent Mainnet (25363)

### DIFF
--- a/deployments.json
+++ b/deployments.json
@@ -1297,6 +1297,11 @@
     "url": "https://blockscout.mainnet.fluence.dev/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
   },
   {
+    "name": "Fluent",
+    "chainId": 25363,
+    "url": "https://fluentscan.xyz/address/0xcA11bde05977b3631167028862bE2a173976CA11"
+  },
+  {
     "name": "Camp Testnet V2",
     "chainId": 325000,
     "url": "https://camp-network-testnet.blockscout.com/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"


### PR DESCRIPTION
Add Multicall3 deployment for Fluent mainnet (chainId: 25363)