### PR TITLE
feat: add HPP Mainnet (190415) and HPP Sepolia (181228)

### DIFF
--- a/deployments.json
+++ b/deployments.json
@@ -1581,5 +1581,15 @@
     "name": "Stable Mainnet",
     "chainId": 988,
     "url": "https://stablescan.xyz/address/0xca11bde05977b3631167028862be2a173976ca11#code"
+  },
+  {
+    "name": "HPP Mainnet",
+    "chainId": 190415,
+    "url": "https://explorer.hpp.io/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
+  },
+  {
+    "name": "HPP Sepolia",
+    "chainId": 181228,
+    "url": "https://sepolia-explorer.hpp.io/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
   }
 ]


### PR DESCRIPTION
Adds the HPP Mainnet and HPP Sepolia deployments of the canonical Multicall3.

Both are Arbitrum Orbit chains. Multicall3 is deployed at the canonical address `0xcA11bde05977b3631167028862bE2a173976CA11` on each, with bytecode byte-identical to the canonical Multicall3 and source verified as `Multicall3` on Blockscout.

| Network | Chain ID | Explorer (verified) |
|---|---|---|
| HPP Mainnet | 190415 | https://explorer.hpp.io/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract |
| HPP Sepolia | 181228 | https://sepolia-explorer.hpp.io/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract |

`getChainId()` returns `190415` / `181228` respectively, and basic aggregate calls work as expected.
